### PR TITLE
POWR-1312 add default services.local files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ The .lando.yml file included in this repo will set you up to connect to the corr
 
 See other Lando with Pantheon commands at https://docs.devwithlando.io/tutorials/pantheon.html.
 
+## Local development mode
+
+By default the site runs in "production" mode locally, which means that caching is on, twig debugging is off, etc. To run the site in development mode (caching off, twig debugging on, etc.), make a copy of web/sites/default/local.services.dev.yml, and rename it local.servcies.yml. This new file should not be committed in Git or deployed and is included in gitignore.
+
 ## Workflow for this repository
 
 We are using a modified version of GitHub Flow to keep things simple. While you don't need to fork the repo if you are on the eGov dev team, you will need to issue pull requests from a feature branch in order to get your code into `master`. Master is a protected branch.

--- a/web/sites/default/services.local.default.yml
+++ b/web/sites/default/services.local.default.yml
@@ -1,0 +1,13 @@
+# Local services, default version
+#
+# This is the default version of the services.local.yml file, which replicates produciton settings.
+# The services.local.yml file is used when running the site locally, but it is not managed 
+# in source control. To run the site locally in production mode, make a copy of this file and
+# rename it services.local.yml. To run the site locally in development mode (caching off, debug on,
+# etc.), make a copy of services.local.dev.yml and rename it services.local.yml.
+parameters:
+  http.response.debug_cacheability_headers: false
+  twig.config:
+    debug: false
+    auto_reload: false
+    cache: true

--- a/web/sites/default/services.local.dev.yml
+++ b/web/sites/default/services.local.dev.yml
@@ -1,0 +1,15 @@
+# Local services, development version
+#
+# This is the development version of the services.local.yml file, which enables various development
+# settings. It is not managed in source control. To run the site in development mode, make a copy 
+# of this file and rename it services.local.yml. To run the site locally in production mode (caching 
+# on, debug off, etc.), make a copy of services.local.default.yml and rename it services.local.yml.
+parameters:
+  http.response.debug_cacheability_headers: true
+  twig.config:
+    debug: true
+    auto_reload: true
+    cache: false
+services:
+  cache.backend.null:
+    class: Drupal\Core\Cache\NullBackendFactory


### PR DESCRIPTION
The main services.local.yml file is not tracked in Git. The site seems to run okay without it, even though it's called by settings.local.php. Two default files have been added: services.local.dev.yml and services.local.prod.yml. Developers should make a copy of one of these two files, depending on the mode they want to use, and rename it services.local.yml.